### PR TITLE
feat: ability to specify redirect uri

### DIFF
--- a/SS14.Admin/Startup.cs
+++ b/SS14.Admin/Startup.cs
@@ -75,6 +75,14 @@ namespace SS14.Admin
                         var handler = ctx.HttpContext.RequestServices.GetRequiredService<LoginHandler>();
                         await handler.HandleTokenValidated(ctx);
                     };
+
+                    if (Configuration["Auth:RedirectUri"] != null) {
+                        options.Events.OnRedirectToIdentityProvider = async ctx =>
+                        {
+                            ctx.ProtocolMessage.RedirectUri = Configuration["Auth:RedirectUri"];
+                            await Task.FromResult(0);
+                        };
+                    }
                 });
         }
 


### PR DESCRIPTION
Kestrel tries to construct this and fails spectacularly if the server is being reverse-proxied.

This change lets you specify e.g. `RedirectUri = "https://admin.example.com/signin-oidc"` in `appsettings.yml`.